### PR TITLE
Include .notFound on errors produced by unfound chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,11 @@ Storage.prototype.get = function (index, opts, cb) {
   if (typeof opts === 'function') return this.get(index, null, opts)
   if (this.closed) return nextTick(cb, new Error('Storage is closed'))
   var buf = this.chunks[index]
-  if (!buf) return nextTick(cb, new Error('Chunk not found'))
+  if (!buf) {
+    var err = new Error('Chunk not found')
+    err.notFound = true
+    return nextTick(cb, err)
+  }
   if (!opts) return nextTick(cb, null, buf)
   var offset = opts.offset || 0
   var len = opts.length || (buf.length - offset)


### PR DESCRIPTION
This change allows the chunk store to both

1. continue to adhere to the `abstract-chunk-store` API
2. indicate that a chunk was not found, instead of a generic error

The `err.notFound` pattern works well in Level, and seems like a good
compromise to keep compatibility here.